### PR TITLE
🐛 FIX: regexp is reading decimal numbers as url

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { Anchor as DefaultAnchor } from "./components/anchor";
 
 const regexp =
-  /(https?:\/\/)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9]{1,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/ig
+  /[(http(s)?):\/\/(www\.)?a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/ig
 
 export default function linkify(
   text: string,


### PR DESCRIPTION
Update the current `regexp` as it reads the decimal numbers as URL 

Issue https://codesandbox.io/s/react-tiny-link-forked-57pn96

New regex test https://regexr.com/39nr7

![image](https://github.com/MaxMEllon/react-tiny-linkify/assets/4944871/f48898f3-3a79-42bc-8dd0-e47a13a1e9c9)